### PR TITLE
prometheus exporter

### DIFF
--- a/etc/emqx_prometheus.conf
+++ b/etc/emqx_prometheus.conf
@@ -2,8 +2,14 @@
 ## Statsd for EMQ X
 ##--------------------------------------------------------------------
 
+## not used. left for compatibility purposes.
 prometheus.push.gateway.server = http://127.0.0.1:9091
 
+## not used. left for compatibility purposes.
 prometheus.interval = 15000
 
 #prometheus.collector.1 = emqx_prometheus
+
+prometheus.port = 9540
+
+prometheus.endpoint = /metrics

--- a/priv/emqx_prometheus.schema
+++ b/priv/emqx_prometheus.schema
@@ -10,6 +10,16 @@
   {datatype, integer}
 ]}.
 
+{mapping, "prometheus.port", "emqx_statsd.port", [
+  {default, 9540},
+  {datatype, integer}
+]}.
+
+{mapping, "prometheus.endpoint", "emqx_statsd.endpoint", [
+  {default, "/metrics"},
+  {datatype, string}
+]}.
+
 {mapping, "prometheus.collector.$name", "prometheus.collectors", [
   {datatype, atom}
 ]}.

--- a/src/emqx_prometheus.erl
+++ b/src/emqx_prometheus.erl
@@ -89,7 +89,7 @@ init(Req0, State) ->
 init([Port, Endpoint]) ->
     Dispatch = cowboy_router:compile([
         {'_', [
-            {Endpoint, emqx_statsd, []}
+            {Endpoint, emqx_prometheus, []}
         ]}
     ]),
     case cowboy:start_clear(http, [{port, Port}], #{

--- a/src/emqx_prometheus_app.erl
+++ b/src/emqx_prometheus_app.erl
@@ -30,7 +30,7 @@
 start(_StartType, _StartArgs) ->
     Port = application:get_env(?APP, port, 9540),
     Endpoint = application:get_env(?APP, endpoint, "/metrics"),
-    emqx_statsd_sup:start_link(Port, Endpoint).
+    emqx_prometheus_sup:start_link(Port, Endpoint).
 
 
 stop(_State) ->

--- a/src/emqx_prometheus_app.erl
+++ b/src/emqx_prometheus_app.erl
@@ -28,10 +28,11 @@
 -define(APP, emqx_prometheus).
 
 start(_StartType, _StartArgs) ->
-    PushGateway = application:get_env(?APP, push_gateway, "http://127.0.0.1:9091"),
-    Interval = application:get_env(?APP, interval, 5000),
-    emqx_prometheus_sup:start_link(PushGateway, Interval).
+    Port = application:get_env(?APP, port, 9540),
+    Endpoint = application:get_env(?APP, endpoint, "/metrics"),
+    emqx_statsd_sup:start_link(Port, Endpoint).
+
 
 stop(_State) ->
-    ok.
+    ok = cowboy:stop_listener(http).
 

--- a/src/emqx_prometheus_sup.erl
+++ b/src/emqx_prometheus_sup.erl
@@ -22,13 +22,13 @@
 
 -export([init/1]).
 
-start_link(PushGateway, Interval) ->
-    supervisor:start_link({local, ?MODULE}, ?MODULE, [PushGateway, Interval]).
+start_link(Port, Endpoint) ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, [Port, Endpoint]).
 
-init([PushGateway, Interval]) ->
+init([Port, Endpoint]) ->
     {ok, {#{strategy => one_for_one, intensity => 10, period => 100},
           [#{id       => emqx_prometheus,
-             start    => {emqx_prometheus, start_link, [PushGateway, Interval]},
+             start    => {emqx_prometheus, start_link, [Port, Endpoint]},
              restart  => permanent,
              shutdown => 5000,
              type     => worker,


### PR DESCRIPTION
Hi, 

im NOT an erlang programmer myself, so any tips/comments are much appreciated.

EMQX uses push-gateway to send its stats into prometheus. according to prometheus docs [https://prometheus.io/docs/practices/pushing/](https://prometheus.io/docs/practices/pushing/) 
this is not the case, emqx should use. 

This PR:
* introduces a single endpoint (/metrics) residing on port 9540 (according to [https://github.com/prometheus/prometheus/wiki/Default-port-allocations](https://github.com/prometheus/prometheus/wiki/Default-port-allocations))

* removes support for push-gateway completely

